### PR TITLE
Add guarded termsrv.dll patch helper for 26100.8521

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The application is portable and has the following features:
   - fix Microsoft account local cache ([#10](https://github.com/sergiye/rdpWrapper/issues/10))
   - configuring display/hide of [client security warnings](https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/remotepc/understanding-security-warnings)
   - configuring client USB device redirection restrictions
+  - optional guarded `termsrv.dll` patch helper for known builds where wrapper mode still leaves Windows restricted to one user
 
   and you can get full/lite/x64/x86 version of the application - the one that best suits your needs
 
@@ -117,6 +118,30 @@ Add-MpPreference -ExclusionPath "c:\Program Files\RDP Wrapper\"
 > If you are uncomfortable with this process, or if your antivirus is managed by your company, we advise against using RdpWrapper. Please consider alternative solutions instead.
 
 ## Notes
+
+### termsrv.dll patch helper
+
+RDP Wrapper normally keeps the original `termsrv.dll` untouched. For known
+Windows builds where wrapper mode still leaves Windows restricted to one user,
+the application also includes an optional guarded patch helper.
+
+For `termsrv.dll` x64 `10.0.26100.8521`, the helper validates that the expected
+byte pattern occurs exactly once, verifies the computed patch offset is
+`0x9C547`, and changes that byte from `75` to `EB`. It backs up the original
+file under `C:\Program Files\RDP Wrapper\termsrv-backups`, replaces the local
+system file, restores `TrustedInstaller` ownership, and restarts `TermService`
+if it was running.
+
+Usage:
+
+- UI: `Tools` -> `Patch termsrv.dll 26100.8521`
+- CLI: `rdpWrapper.exe -patchtermsrv`
+- Restore: `Tools` -> `Restore termsrv.dll backup`
+- Restore CLI: `rdpWrapper.exe -restoretermsrv`
+
+Do not use DLLs downloaded from third-party file sharing links. Patch only the
+local system file, and re-check after Windows updates because servicing may
+restore `termsrv.dll`.
 
 ### Enable USB redirection
 To enable remote desktop USB redirection, additional group policy settings are required (gpedit):

--- a/rdpWrapper/MainForm.Designer.cs
+++ b/rdpWrapper/MainForm.Designer.cs
@@ -61,6 +61,8 @@ namespace rdpWrapper {
       this.uninstallMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.restartServiceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.generateMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.patchTermsrvMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+      this.restoreTermsrvMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripSeparator();
       this.addUserToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
       this.fixMSUserMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -499,6 +501,8 @@ namespace rdpWrapper {
             this.uninstallMenuItem,
             this.restartServiceMenuItem,
             this.generateMenuItem,
+            this.patchTermsrvMenuItem,
+            this.restoreTermsrvMenuItem,
             this.toolStripMenuItem3,
             this.addUserToolStripMenuItem,
             this.fixMSUserMenuItem,
@@ -535,6 +539,20 @@ namespace rdpWrapper {
       this.generateMenuItem.Size = new System.Drawing.Size(251, 22);
       this.generateMenuItem.Text = "Generate \'wrap.ini\'";
       this.generateMenuItem.Click += new System.EventHandler(this.btnGenerate_Click);
+      //
+      // patchTermsrvMenuItem
+      //
+      this.patchTermsrvMenuItem.Name = "patchTermsrvMenuItem";
+      this.patchTermsrvMenuItem.Size = new System.Drawing.Size(251, 22);
+      this.patchTermsrvMenuItem.Text = "Patch termsrv.dll 26100.8521";
+      this.patchTermsrvMenuItem.Click += new System.EventHandler(this.patchTermsrvMenuItem_Click);
+      //
+      // restoreTermsrvMenuItem
+      //
+      this.restoreTermsrvMenuItem.Name = "restoreTermsrvMenuItem";
+      this.restoreTermsrvMenuItem.Size = new System.Drawing.Size(251, 22);
+      this.restoreTermsrvMenuItem.Text = "Restore termsrv.dll backup";
+      this.restoreTermsrvMenuItem.Click += new System.EventHandler(this.restoreTermsrvMenuItem_Click);
       // 
       // toolStripMenuItem3
       // 
@@ -755,6 +773,8 @@ namespace rdpWrapper {
     private ToolStripMenuItem installMenuItem;
     private ToolStripMenuItem uninstallMenuItem;
     private ToolStripMenuItem generateMenuItem;
+    private ToolStripMenuItem patchTermsrvMenuItem;
+    private ToolStripMenuItem restoreTermsrvMenuItem;
     private ToolStripMenuItem editWrapIniMenuItem;
     private ToolStripMenuItem restartServiceMenuItem;
     private ToolStripMenuItem addUserToolStripMenuItem;

--- a/rdpWrapper/MainForm.cs
+++ b/rdpWrapper/MainForm.cs
@@ -563,6 +563,56 @@ namespace rdpWrapper {
       }
     }
 
+    private void patchTermsrvMenuItem_Click(object sender, EventArgs e) {
+      if (MessageBox.Show(
+            "This will patch C:\\Windows\\System32\\termsrv.dll for the 10.0.26100.8521 byte pattern and restart TermService. Continue?",
+            Updater.ApplicationTitle,
+            MessageBoxButtons.OKCancel,
+            MessageBoxIcon.Warning) != DialogResult.OK) {
+        return;
+      }
+
+      try {
+        SetControlsState(false);
+        var result = wrapper.ApplyTermsrvPatch26100_8521();
+        logger.Log(result, Logger.StateKind.Info);
+        MessageBox.Show(result, Updater.ApplicationTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
+      }
+      catch (Exception ex) {
+        var message = "Failed to patch termsrv.dll: " + ex.Message;
+        logger.Log(message, Logger.StateKind.Error);
+        MessageBox.Show(message, Updater.ApplicationTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+      }
+      finally {
+        SetControlsState(true);
+      }
+    }
+
+    private void restoreTermsrvMenuItem_Click(object sender, EventArgs e) {
+      if (MessageBox.Show(
+            "This will restore the latest backed up termsrv.dll and restart TermService. Continue?",
+            Updater.ApplicationTitle,
+            MessageBoxButtons.OKCancel,
+            MessageBoxIcon.Warning) != DialogResult.OK) {
+        return;
+      }
+
+      try {
+        SetControlsState(false);
+        var result = wrapper.RestoreTermsrvPatch26100_8521();
+        logger.Log(result, Logger.StateKind.Info);
+        MessageBox.Show(result, Updater.ApplicationTitle, MessageBoxButtons.OK, MessageBoxIcon.Information);
+      }
+      catch (Exception ex) {
+        var message = "Failed to restore termsrv.dll: " + ex.Message;
+        logger.Log(message, Logger.StateKind.Error);
+        MessageBox.Show(message, Updater.ApplicationTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
+      }
+      finally {
+        SetControlsState(true);
+      }
+    }
+
     private void btnEditWrapIni_Click(object sender, EventArgs e) {
       try {
         SetControlsState(false);
@@ -641,6 +691,7 @@ namespace rdpWrapper {
         btnInstall.Enabled = installMenuItem.Enabled = uninstallMenuItem.Enabled = false;
         editWrapIniMenuItem.Enabled = btnGenerate.Enabled = generateMenuItem.Enabled = false;
       }
+      patchTermsrvMenuItem.Enabled = restoreTermsrvMenuItem.Enabled = enabled;
       btnRestartService.Enabled = restartServiceMenuItem.Enabled = enabled;
     }
 

--- a/rdpWrapper/Program.cs
+++ b/rdpWrapper/Program.cs
@@ -91,7 +91,7 @@ namespace rdpWrapper {
         switch (args[0]) {
           case "-help":
             //todo: show help with supported options
-            logger.Log("Usage:\n -x \t start UI and no wait for exit;\n -generate \t generate Ini;\n -install \t install wrapper;\n -uninstall \t uninstall wrapper", Logger.StateKind.Info);
+            logger.Log("Usage:\n -x \t start UI and no wait for exit;\n -generate \t generate Ini;\n -install \t install wrapper;\n -uninstall \t uninstall wrapper;\n -patchtermsrv \t patch termsrv.dll for 10.0.26100.8521;\n -restoretermsrv \t restore latest termsrv.dll backup", Logger.StateKind.Info);
             break;
           case "-x":
             //start UI as a new separate process
@@ -132,6 +132,16 @@ namespace rdpWrapper {
           case "-stop": {
             var wrapper = new Wrapper(logger);
             wrapper.StopService(TimeSpan.FromSeconds(10));
+            break;
+          }
+          case "-patchtermsrv": {
+            var wrapper = new Wrapper(logger);
+            logger.Log(wrapper.ApplyTermsrvPatch26100_8521(), Logger.StateKind.Info);
+            break;
+          }
+          case "-restoretermsrv": {
+            var wrapper = new Wrapper(logger);
+            logger.Log(wrapper.RestoreTermsrvPatch26100_8521(), Logger.StateKind.Info);
             break;
           }
           default:

--- a/rdpWrapper/Wrapper.cs
+++ b/rdpWrapper/Wrapper.cs
@@ -61,6 +61,7 @@ namespace rdpWrapper {
     private const string UmWrapDllName = "UmWrap.dll";
     private const string EndpWrapDllName = "EndpWrap.dll";
     private const string ZydisDllName = "Zydis.dll";
+    private const int TermsrvPatch26100_8521Offset = 0x9C547;
 
     private readonly Logger logger;
     private readonly ServiceHelper serviceHelper;
@@ -401,6 +402,116 @@ namespace rdpWrapper {
 
     internal ServiceControllerStatus? GetServiceState() {
       return serviceHelper.GetState(RdpServiceName);
+    }
+
+    #endregion
+
+    #region termsrv.dll patching
+
+    internal string ApplyTermsrvPatch26100_8521() {
+      return PatchTermsrv26100_8521(applyPatch: true);
+    }
+
+    internal string RestoreTermsrvPatch26100_8521() {
+      var backupPath = GetLatestTermsrvBackup();
+      if (backupPath.IsNullOrEmpty())
+        throw new FileNotFoundException("No termsrv.dll backup was found.");
+
+      ReplaceTermsrvFile(backupPath);
+      return "Restored termsrv.dll from: " + backupPath;
+    }
+
+    private string PatchTermsrv26100_8521(bool applyPatch) {
+      var bytes = File.ReadAllBytes(TermSrvFile);
+      var patchOffset = FindTermsrvPatchOffset(bytes);
+      var currentByte = bytes[patchOffset];
+      if (currentByte == 0xEB)
+        return "termsrv.dll is already patched at 0x9C547.";
+      if (currentByte != 0x75)
+        throw new InvalidOperationException($"Unexpected byte at 0x9C547: 0x{currentByte:X2}.");
+
+      if (!applyPatch)
+        return "termsrv.dll can be patched at 0x9C547.";
+
+      Directory.CreateDirectory(WrapperFolderPath);
+      var backupDir = Path.Combine(WrapperFolderPath, "termsrv-backups");
+      Directory.CreateDirectory(backupDir);
+
+      var stamp = DateTime.Now.ToString("yyyyMMdd-HHmmss");
+      var backupPath = Path.Combine(backupDir, $"termsrv.dll.{stamp}.original");
+      var patchedPath = Path.Combine(backupDir, $"termsrv.dll.{stamp}.patched");
+
+      File.Copy(TermSrvFile, backupPath, overwrite: false);
+      bytes[patchOffset] = 0xEB;
+      File.WriteAllBytes(patchedPath, bytes);
+
+      ReplaceTermsrvFile(patchedPath);
+      return $"Patched termsrv.dll at 0x9C547. Original backup: {backupPath}";
+    }
+
+    private static int FindTermsrvPatchOffset(byte[] bytes) {
+      var patternPrefix = new byte[] { 0x8B, 0x8F, 0x38, 0x06, 0x00, 0x00, 0x45, 0x3B, 0xC1 };
+      var matches = 0;
+      var matchOffset = -1;
+
+      for (var i = 0; i <= bytes.Length - patternPrefix.Length - 1; i++) {
+        var ok = true;
+        for (var j = 0; j < patternPrefix.Length; j++) {
+          if (bytes[i + j] == patternPrefix[j]) continue;
+          ok = false;
+          break;
+        }
+
+        if (!ok) continue;
+        matches++;
+        matchOffset = i;
+      }
+
+      if (matches != 1)
+        throw new InvalidOperationException($"Expected one termsrv.dll patch pattern match, found {matches}.");
+
+      var patchOffset = matchOffset + patternPrefix.Length;
+      if (patchOffset != TermsrvPatch26100_8521Offset)
+        throw new InvalidOperationException($"Patch offset mismatch: 0x{patchOffset:X}, expected 0x{TermsrvPatch26100_8521Offset:X}.");
+
+      return patchOffset;
+    }
+
+    private void ReplaceTermsrvFile(string sourceFilePath) {
+      var serviceState = serviceHelper.GetState(RdpServiceName);
+      if (serviceState is ServiceControllerStatus.Running)
+        serviceHelper.Stop(RdpServiceName, TimeSpan.FromSeconds(10));
+
+      try {
+        RunSystemTool("takeown.exe", $"/F \"{TermSrvFile}\"");
+        RunSystemTool("icacls.exe", $"\"{TermSrvFile}\" /grant *S-1-5-32-544:F");
+
+        File.Copy(sourceFilePath, TermSrvFile, overwrite: true);
+
+        RunSystemTool("icacls.exe", $"\"{TermSrvFile}\" /setowner \"NT SERVICE\\TrustedInstaller\"");
+      }
+      finally {
+        if (serviceState is ServiceControllerStatus.Running)
+          serviceHelper.Start(RdpServiceName, TimeSpan.FromSeconds(10));
+      }
+    }
+
+    private static void RunSystemTool(string app, string arguments) {
+      using var process = StartProcess(app, arguments);
+      process.WaitForExit();
+      if (process.ExitCode != 0)
+        throw new InvalidOperationException($"{app} failed with exit code {process.ExitCode}.");
+    }
+
+    private string GetLatestTermsrvBackup() {
+      var backupDir = Path.Combine(WrapperFolderPath, "termsrv-backups");
+      if (!Directory.Exists(backupDir))
+        return null;
+
+      return Directory
+        .EnumerateFiles(backupDir, "termsrv.dll.*.original")
+        .OrderByDescending(File.GetLastWriteTime)
+        .FirstOrDefault();
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Add a guarded optional helper for the known termsrv.dll x64 10.0.26100.8521 byte patch.
- Expose it from Tools menu and CLI (`-patchtermsrv`, `-restoretermsrv`).
- Back up the original DLL, validate the exact byte pattern and offset before patching, restore TrustedInstaller ownership, and restart TermService only if it was running.

## Notes
- This is intended as a fallback for builds where wrapper mode still leaves Windows restricted to one user.
- The helper does not download or trust third-party DLLs; it only patches the local system file after exact validation.

## Testing
- `git diff --check` passes.
- Could not run MSBuild locally because the environment has no dotnet/MSBuild/VS Build Tools available.